### PR TITLE
style(gurubu-client): update navbar styling for mobile view

### DIFF
--- a/gurubu-client/src/app/styles/common/navbar.scss
+++ b/gurubu-client/src/app/styles/common/navbar.scss
@@ -97,9 +97,7 @@
 
 @media (max-width: 768px) {
   .nav {
-    @include container;
-    padding-top: $space-large;
-    padding-bottom: $space-large;
+    padding: $space-large $space-xxlarge;
     &__content {
       justify-content: space-between;
       &--links {


### PR DESCRIPTION
This PR is related with #118. 

There is a inconsistency in the padding of the sections. In the Hero section, the side paddings are 16px, while in other sections they are 32px. Therefore, I set the side paddings of the navbar to 32px. I can also update it to 16px if you wish.

How it looks together with the hero section
![image](https://github.com/Trendyol/gurubu/assets/14194501/d7769082-6d49-4b39-beec-c1ace1b7458e)

How it looks together with the pricing section
![image](https://github.com/Trendyol/gurubu/assets/14194501/053e97bc-f596-46cd-b0ff-2e726cc3a8c5)

