### PR TITLE
feat: Added share link option to gurubu planner

### DIFF
--- a/gurubu-client/src/app/contexts/PlannerContext.tsx
+++ b/gurubu-client/src/app/contexts/PlannerContext.tsx
@@ -1,0 +1,175 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from "react";
+import { useSearchParams } from "next/navigation";
+import { Sprint } from "../gurubu-planner/components/SprintDropdown";
+import { PService } from "@/services/pService";
+import { JiraService } from "@/services/jiraService";
+
+interface PlannerContextType {
+  selectedSprint: Sprint | null;
+  setSelectedSprint: (sprint: Sprint | null) => void;
+  hasTeamSelected: boolean;
+  selectedTeam: string | null;
+  refreshTrigger: number;
+  handleRefresh: () => void;
+  showTeamSelect: boolean;
+  setShowTeamSelect: (show: boolean) => void;
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+  sprints: Sprint[];
+  setSprints: (sprints: Sprint[]) => void;
+  selectTeam: (teamName: string, boardId: string) => Promise<void>;
+  hasEmptyTeam: boolean;
+  setHasEmptyTeam: (isEmpty: boolean) => void;
+}
+
+interface PlannerProviderProps {
+  children: ReactNode;
+}
+
+const PlannerContext = createContext<PlannerContextType | null>(null);
+
+export const PlannerProvider: React.FC<PlannerProviderProps> = ({ children }) => {
+  const searchParams = useSearchParams();
+  const [selectedSprint, setSelectedSprint] = useState<Sprint | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [sprints, setSprints] = useState<Sprint[]>([]);
+  const [showTeamSelect, setShowTeamSelect] = useState(false);
+  const [hasTeamSelected, setHasTeamSelected] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+  const [hasEmptyTeam, setHasEmptyTeam] = useState(false);
+
+  const pService = new PService(process.env.NEXT_PUBLIC_API_URL || "");
+  const jiraService = new JiraService(process.env.NEXT_PUBLIC_API_URL || "");
+
+  const handleRefresh = useCallback(() => {
+    setRefreshTrigger((prev) => prev + 1);
+  }, []);
+
+  const selectTeam = useCallback(async (teamName: string, boardId: string) => {
+    setLoading(true);
+    
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.set('team', teamName);
+      url.searchParams.set('board', boardId);
+      window.history.pushState({}, '', url.toString());
+      
+      setSelectedTeam(teamName);
+      setHasTeamSelected(true);
+      
+      const organisationResponse = await pService.getOrganization(teamName);
+      
+      if (organisationResponse.isSuccess && organisationResponse.data) {
+        const { developer, qa } = organisationResponse.data.metadata;
+        const teamAssignees = [...developer, ...qa];
+        
+        localStorage.setItem('JIRA_DEFAULT_ASSIGNEES', JSON.stringify(teamAssignees));
+        localStorage.setItem('JIRA_TEAM_NAME', teamName);
+        localStorage.setItem('JIRA_BOARD', boardId);
+        
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/jira/${boardId}/future`
+        );
+        
+        if (response.ok) {
+          const data = await response.json();
+          setSprints(data.values);
+        }
+        
+        setHasEmptyTeam(teamAssignees.length === 0);
+      } else {
+        localStorage.setItem('JIRA_TEAM_NAME', teamName);
+        localStorage.setItem('JIRA_BOARD', boardId);
+        localStorage.setItem('JIRA_DEFAULT_ASSIGNEES', JSON.stringify([]));
+        
+        setHasEmptyTeam(true);
+      }
+      
+      handleRefresh();
+    } catch (error) {
+      console.error("Error in selectTeam:", error);
+      localStorage.setItem('JIRA_TEAM_NAME', teamName);
+      localStorage.setItem('JIRA_BOARD', boardId);
+      setHasEmptyTeam(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [pService, handleRefresh]);
+
+  useEffect(() => {
+    const updateTeamStatus = () => {
+      const teamFromUrl = searchParams.get('team');
+      const boardFromUrl = searchParams.get('board');
+      const storedTeamName = localStorage.getItem('JIRA_TEAM_NAME');
+      const hasAssignees = !!localStorage.getItem('JIRA_DEFAULT_ASSIGNEES');
+      
+      if (teamFromUrl && boardFromUrl) {
+        setSelectedTeam(teamFromUrl);
+        setHasTeamSelected(true);
+        
+        if (storedTeamName !== teamFromUrl || !hasAssignees) {
+          (async () => {
+            try {
+              await selectTeam(teamFromUrl, boardFromUrl);
+            } catch (error) {
+              console.error("Error fetching team data from URL:", error);
+            }
+          })();
+        }
+      } else if (storedTeamName && hasAssignees) {
+        setSelectedTeam(storedTeamName);
+        setHasTeamSelected(true);
+      } else {
+        setHasTeamSelected(false);
+        setSelectedTeam(null);
+      }
+    };
+    
+    updateTeamStatus();
+    window.addEventListener('storage', updateTeamStatus);
+    
+    return () => {
+      window.removeEventListener('storage', updateTeamStatus);
+    };
+  }, [searchParams, selectTeam]);
+
+  const contextValue: PlannerContextType = {
+    selectedSprint,
+    setSelectedSprint,
+    hasTeamSelected,
+    selectedTeam,
+    refreshTrigger,
+    handleRefresh,
+    showTeamSelect,
+    setShowTeamSelect,
+    loading,
+    setLoading,
+    sprints,
+    setSprints,
+    selectTeam,
+    hasEmptyTeam,
+    setHasEmptyTeam
+  };
+
+  return (
+    <PlannerContext.Provider value={contextValue}>
+      {children}
+    </PlannerContext.Provider>
+  );
+};
+
+export const usePlanner = (): PlannerContextType => {
+  const context = useContext(PlannerContext);
+  if (!context) {
+    throw new Error("usePlanner must be used within a PlannerProvider");
+  }
+  return context;
+}; 

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PlannerTable from './PlannerTable';
 import { SelectTeamForm } from './SelectTeamForm';
 import { Sprint } from '../components/SprintDropdown';
 import { Modal } from '@/components/common/modal';
 import { IconUsers } from '@tabler/icons-react';
-
+import { useSearchParams } from 'next/navigation';
 interface PlannerContentProps {
   setSprints: (sprint: Sprint[]) => void;
   selectedSprintId: number | null;
@@ -20,7 +20,6 @@ interface PlannerContentProps {
   hasTeamSelected: boolean;
   loading: boolean;
   setLoading: (value: boolean) => void;
-  selectedTeam: string | null;
 }
 
 export const PlannerContent: React.FC<PlannerContentProps> = ({
@@ -33,15 +32,27 @@ export const PlannerContent: React.FC<PlannerContentProps> = ({
   handleTeamSelectClick,
   hasTeamSelected,
   loading,
-  setLoading,
-  selectedTeam
+  setLoading
 }) => {
+  const searchParams = useSearchParams();
   const [hasEmptyTeam, setHasEmptyTeam] = useState(false);
+  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+
+  useEffect(() => {
+    const teamFromUrl = searchParams.get('team');
+    const storedTeam = localStorage.getItem('JIRA_TEAM_NAME');
+    
+    // Önce URL'den takım bilgisini kontrol et, yoksa localStorage'dan al
+    const effectiveTeam = teamFromUrl || storedTeam;
+    setSelectedTeam(effectiveTeam);
+    
+    console.log("Setting selectedTeam from", teamFromUrl ? "URL" : "localStorage", ":", effectiveTeam);
+  }, [searchParams]);
 
   const handleEmptyTeam = (isEmpty: boolean) => {
     setHasEmptyTeam(isEmpty);
   };
-
+  console.log("hasTeamSelected", hasTeamSelected, "selectedTeam", selectedTeam);
   return (
     <div className="gurubu-planner-content">
       {selectedTeam && (

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React from "react";
-import PlannerTable from "./PlannerTable";
-import { SelectTeamForm } from "./SelectTeamForm";
-import { Sprint } from "../components/SprintDropdown";
-import { Modal } from "@/components/common/modal";
-import { IconUsers } from "@tabler/icons-react";
+import React, { useState } from 'react';
+import PlannerTable from './PlannerTable';
+import { SelectTeamForm } from './SelectTeamForm';
+import { Sprint } from '../components/SprintDropdown';
+import { Modal } from '@/components/common/modal';
+import { IconUsers } from '@tabler/icons-react';
 
 interface PlannerContentProps {
   setSprints: (sprint: Sprint[]) => void;
@@ -20,6 +20,7 @@ interface PlannerContentProps {
   hasTeamSelected: boolean;
   loading: boolean;
   setLoading: (value: boolean) => void;
+  selectedTeam: string | null;
 }
 
 export const PlannerContent: React.FC<PlannerContentProps> = ({
@@ -33,9 +34,19 @@ export const PlannerContent: React.FC<PlannerContentProps> = ({
   hasTeamSelected,
   loading,
   setLoading,
+  selectedTeam
 }) => {
+  const [hasEmptyTeam, setHasEmptyTeam] = useState(false);
+
+  const handleEmptyTeam = (isEmpty: boolean) => {
+    setHasEmptyTeam(isEmpty);
+  };
+
   return (
     <div className="gurubu-planner-content">
+      {selectedTeam && (
+        <div className="selected-team-title">Selected Team: {selectedTeam}</div>
+      )}
       <Modal isOpen={showTeamSelect} onClose={handleCloseTeamSelect}>
         <SelectTeamForm
           setSprints={setSprints}
@@ -46,20 +57,43 @@ export const PlannerContent: React.FC<PlannerContentProps> = ({
       </Modal>
 
       {!hasTeamSelected ? (
-        <div className="no-team-message">
-          <IconUsers size={48} />
-          <h3>No Team Selected</h3>
-          <p>Please select a team to view sprint statistics</p>
-          <button onClick={handleTeamSelectClick}>Select Team</button>
-        </div>
+        <EmptyStateMessage 
+          title="No Team Selected"
+          message="Please select a team to view sprint statistics"
+          onButtonClick={handleTeamSelectClick}
+        />
+      ) : hasEmptyTeam ? (
+        <EmptyStateMessage 
+          title="Selected Team Has No Members"
+          message="The selected team has no members. Please select a different team."
+          onButtonClick={handleTeamSelectClick}
+        />
       ) : (
         <PlannerTable
           selectedSprintId={selectedSprintId}
           refreshTrigger={refreshTrigger}
           loading={loading}
           setLoading={setLoading}
+          onEmptyTeam={handleEmptyTeam}
         />
       )}
     </div>
   );
 };
+
+const EmptyStateMessage = ({ 
+  title, 
+  message, 
+  onButtonClick 
+}: { 
+  title: string; 
+  message: string; 
+  onButtonClick: () => void;
+}) => (
+  <div className="no-team-message">
+    <IconUsers size={48} />
+    <h3>{title}</h3>
+    <p>{message}</p>
+    <button onClick={onButtonClick}>Select Team</button>
+  </div>
+);

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerContent.tsx
@@ -1,58 +1,35 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PlannerTable from './PlannerTable';
 import { SelectTeamForm } from './SelectTeamForm';
-import { Sprint } from '../components/SprintDropdown';
 import { Modal } from '@/components/common/modal';
 import { IconUsers } from '@tabler/icons-react';
-import { useSearchParams } from 'next/navigation';
+import { usePlanner } from '@/contexts/PlannerContext';
+
 interface PlannerContentProps {
-  setSprints: (sprint: Sprint[]) => void;
   selectedSprintId: number | null;
-  refreshTrigger: number;
-  handleRefresh: () => void;
-  selectedSprint: Sprint | null;
-  onSprintSelect: (sprint: Sprint | null) => void;
-  showTeamSelect: boolean;
-  handleCloseTeamSelect: () => void;
-  handleTeamSelectClick: () => void;
-  hasTeamSelected: boolean;
-  loading: boolean;
-  setLoading: (value: boolean) => void;
 }
 
 export const PlannerContent: React.FC<PlannerContentProps> = ({
-  setSprints,
-  selectedSprintId,
-  refreshTrigger,
-  handleRefresh,
-  showTeamSelect,
-  handleCloseTeamSelect,
-  handleTeamSelectClick,
-  hasTeamSelected,
-  loading,
-  setLoading
+  selectedSprintId
 }) => {
-  const searchParams = useSearchParams();
-  const [hasEmptyTeam, setHasEmptyTeam] = useState(false);
-  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+  const {
+    hasTeamSelected,
+    selectedTeam,
+    showTeamSelect,
+    setShowTeamSelect,
+    hasEmptyTeam,
+  } = usePlanner();
 
-  useEffect(() => {
-    const teamFromUrl = searchParams.get('team');
-    const storedTeam = localStorage.getItem('JIRA_TEAM_NAME');
-    
-    // Önce URL'den takım bilgisini kontrol et, yoksa localStorage'dan al
-    const effectiveTeam = teamFromUrl || storedTeam;
-    setSelectedTeam(effectiveTeam);
-    
-    console.log("Setting selectedTeam from", teamFromUrl ? "URL" : "localStorage", ":", effectiveTeam);
-  }, [searchParams]);
-
-  const handleEmptyTeam = (isEmpty: boolean) => {
-    setHasEmptyTeam(isEmpty);
+  const handleCloseTeamSelect = () => {
+    setShowTeamSelect(false);
   };
-  console.log("hasTeamSelected", hasTeamSelected, "selectedTeam", selectedTeam);
+
+  const handleTeamSelectClick = () => {
+    setShowTeamSelect(true);
+  };
+
   return (
     <div className="gurubu-planner-content">
       {selectedTeam && (
@@ -60,10 +37,7 @@ export const PlannerContent: React.FC<PlannerContentProps> = ({
       )}
       <Modal isOpen={showTeamSelect} onClose={handleCloseTeamSelect}>
         <SelectTeamForm
-          setSprints={setSprints}
-          handleRefresh={handleRefresh}
           closeModal={handleCloseTeamSelect}
-          setLoading={setLoading}
         />
       </Modal>
 
@@ -82,10 +56,6 @@ export const PlannerContent: React.FC<PlannerContentProps> = ({
       ) : (
         <PlannerTable
           selectedSprintId={selectedSprintId}
-          refreshTrigger={refreshTrigger}
-          loading={loading}
-          setLoading={setLoading}
-          onEmptyTeam={handleEmptyTeam}
         />
       )}
     </div>

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerNavbar.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerNavbar.tsx
@@ -1,13 +1,35 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import PlannerLogo from './PlannerLogo';
+import { IconClipboardCheck, IconCopy } from '@tabler/icons-react';
 
 const PlannerNavbar = () => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(window.location.href)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(err => {
+        console.error('Failed to copy URL: ', err);
+      });
+  };
+
   return (
     <nav className="gurubu-planner-navbar">
       <div className="gurubu-planner-navbar-content">
         <PlannerLogo />
+        <div className="gurubu-planner-navbar-content-copy-link" onClick={handleCopyLink}>
+          {copied ? (
+            <IconClipboardCheck size={20} />
+          ) : (
+            <IconCopy size={20} />
+          )}
+          Link
+        </div>
       </div>
     </nav>
   );

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerTable.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerTable.tsx
@@ -36,6 +36,7 @@ interface PlannerTableProps {
   refreshTrigger: number;
   setLoading: (isLoading: boolean) => void;
   loading: boolean;
+  onEmptyTeam: (isEmpty: boolean) => void;
 }
 
 const LoadingSkeleton = () => {
@@ -81,6 +82,7 @@ const PlannerTable: React.FC<PlannerTableProps> = ({
   refreshTrigger,
   setLoading,
   loading,
+  onEmptyTeam
 }) => {
   const [statistics, setStatistics] =
     React.useState<SprintStatisticsResponse | null>(null);
@@ -135,7 +137,14 @@ const PlannerTable: React.FC<PlannerTableProps> = ({
           );
         }
         const data: SprintStatisticsResponse = await response.json();
-        setStatistics(data);
+        
+        if (data.statistics.length === 0) {
+          onEmptyTeam(true);
+        } else {
+          onEmptyTeam(false);
+          setStatistics(data);
+        }
+        
         setLoading(false);
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {

--- a/gurubu-client/src/app/gurubu-planner/components/PlannerTable.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/PlannerTable.tsx
@@ -112,10 +112,31 @@ const PlannerTable: React.FC<PlannerTableProps> = ({
       try {
         const assigneesData = localStorage.getItem("JIRA_DEFAULT_ASSIGNEES");
         if (!assigneesData) {
-          throw new Error("No team selected");
+          // Return early or signal empty team to parent
+          onEmptyTeam(true);
+          return null;
         }
 
         const assignees: string[] = JSON.parse(assigneesData);
+        
+        // Dizinin boş olup olmadığını kontrol et
+        // URL ilk yüklemesinde boş dizi kullanılıyor olabilir
+        if (assignees.length === 0) {
+          console.log("Empty assignees array, trying with teamFromUrl");
+          const teamFromUrl = new URL(window.location.href).searchParams.get('team');
+          
+          // URL'de takım varsa, henüz veriler yükleniyor olabilir
+          // Kullanıcıya "Loading team data..." benzeri bir durum gösterilebilir
+          if (teamFromUrl) {
+            // API çağrısı yapmak yerine sadece ekranı güncelle
+            setLoading(true);
+            return null;
+          } else {
+            onEmptyTeam(true);
+            return null;
+          }
+        }
+        
         const response = await fetch(
           `${process.env.NEXT_PUBLIC_API_URL}/jira/${selectedSprintId}/statistics`,
           {

--- a/gurubu-client/src/app/gurubu-planner/components/SelectTeamForm.tsx
+++ b/gurubu-client/src/app/gurubu-planner/components/SelectTeamForm.tsx
@@ -8,6 +8,8 @@ import { Board } from "@/shared/interfaces";
 import { Sprint } from "../components/SprintDropdown";
 import { Dropdown, DropdownOption } from "../../../ui-kit/dropdown";
 import { Assignee } from "types/pandora";
+import { useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 type Props = {
   handleRefresh: () => void;
@@ -35,36 +37,81 @@ export const SelectTeamForm = ({
   const [boards, setBoards] = useState<Board[]>([]);
   const [selectedJiraBoardId, setSelectedJiraBoardId] = useState<string>("");
   const { setShowLoader } = useLoader();
+  const searchParams = useSearchParams();
+
+  const router = useRouter();
 
   const pService = new PService(process.env.NEXT_PUBLIC_API_URL || "");
   const jiraService = new JiraService(process.env.NEXT_PUBLIC_API_URL || "");
 
   useEffect(() => {
     fetchTeams();
-  }, []);
+    const teamFromUrl = searchParams.get('team');
+    const boardFromUrl = searchParams.get('board');
+    
+    if (teamFromUrl) {
+      console.log("Setting team from URL:", teamFromUrl);
+      setSelectedTeam(teamFromUrl);
+
+      // URL'den takım geldiğinde hemen localStorage'a geçici olarak bilgiyi kaydet
+      // bu ilk yüklemede takım görüntülenmesini sağlar
+      localStorage.setItem('JIRA_TEAM_NAME', teamFromUrl);
+      
+      // Eğer localStorage'da henüz takım verisi yoksa, boş bir dizi ekle
+      // bu sayede hasTeamSelected true olabilir
+      if (!localStorage.getItem('JIRA_DEFAULT_ASSIGNEES')) {
+        localStorage.setItem('JIRA_DEFAULT_ASSIGNEES', JSON.stringify([]));
+      }
+      
+      if (boardFromUrl) {
+        localStorage.setItem('JIRA_BOARD', boardFromUrl);
+      }
+      
+      (async () => {
+        try {
+          const organisationResponse = await pService.getOrganization(teamFromUrl);
+          
+          if (organisationResponse.isSuccess && organisationResponse.data) {
+            localStorage.removeItem('JIRA_TEAM_NAME');
+            localStorage.removeItem('JIRA_DEFAULT_ASSIGNEES');
+            
+            const { developer, qa } = organisationResponse.data.metadata;
+            const teamAssignees = [...developer, ...qa];
+            
+            setAssignees(teamAssignees);
+            localStorage.setItem('JIRA_DEFAULT_ASSIGNEES', JSON.stringify(teamAssignees));
+            localStorage.setItem('JIRA_TEAM_NAME', teamFromUrl);
+            
+            const boardsResponse = await jiraService.getBoardsByProjectKey(
+              organisationResponse.data.metadata["jira-projects"][0].key
+            );
+            
+            if (boardsResponse.isSuccess && boardsResponse.data) {
+              setBoards(boardsResponse.data);
+              
+              if (boardFromUrl) {
+                setSelectedJiraBoardId(boardFromUrl);
+                localStorage.setItem('JIRA_BOARD', boardFromUrl);
+                
+                const response = await fetch(
+                  `${process.env.NEXT_PUBLIC_API_URL}/jira/${boardFromUrl}/future`
+                );
+                const data = await response.json();
+                setSprints(data.values);
+                handleRefresh();
+              }
+            }
+          }
+        } catch (error) {
+          console.error("Error fetching team data from URL params:", error);
+        }
+      })();
+    }
+  }, [searchParams]);
 
   const handleTeamSelect = async (option: DropdownOption) => {
     if (!option?.value) return;
-    setSelectedTeam(option.value);
-    setShowLoader(true);
-
-    const organisationResponse = await pService.getOrganization(option.value);
-
-    if (organisationResponse.isSuccess && organisationResponse.data) {
-      const { developer, qa } = organisationResponse.data.metadata;
-
-      setAssignees([...developer, ...qa]);
-
-      const boardsResponse = await jiraService.getBoardsByProjectKey(
-        organisationResponse.data.metadata["jira-projects"][0].key
-      );
-
-      if (boardsResponse.isSuccess && boardsResponse.data) {
-        setBoards(boardsResponse.data);
-      }
-    }
-
-    setShowLoader(false);
+    handleTeamSelectionAndFetchData(option.value);
   };
 
   const fetchTeams = async () => {
@@ -93,13 +140,88 @@ export const SelectTeamForm = ({
       setSprints(data.values);
       localStorage.setItem("JIRA_DEFAULT_ASSIGNEES", JSON.stringify(assignees));
       localStorage.setItem("JIRA_BOARD", selectedJiraBoardId);
+      localStorage.setItem("JIRA_TEAM_NAME", selectedTeam);
+      
+      const url = new URL(window.location.href);
+      url.searchParams.set('team', selectedTeam);
+      url.searchParams.set('board', selectedJiraBoardId);
+      window.history.pushState({}, '', url.toString());
+      
       handleClearForm();
       handleRefresh();
       if (closeModal) {
         closeModal();
       }
+      
+      window.location.reload();
     } catch (error) {
       console.error("Error fetching future sprints:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchBoardData = async (boardId: string) => {
+    setLoading(true);
+    try {
+      console.log("Fetching data for board:", boardId);
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/jira/${boardId}/future`
+      );
+      const data: SprintResponse = await response.json();
+      setSprints(data.values);
+      localStorage.setItem("JIRA_BOARD", boardId);
+      handleRefresh();
+      
+      const teamFromUrl = searchParams.get('team');
+      if (teamFromUrl) {
+        const organisationResponse = await pService.getOrganization(teamFromUrl);
+        if (organisationResponse.isSuccess && organisationResponse.data) {
+          const { developer, qa } = organisationResponse.data.metadata;
+          const teamAssignees = [...developer, ...qa];
+          setAssignees(teamAssignees);
+          localStorage.setItem("JIRA_DEFAULT_ASSIGNEES", JSON.stringify(teamAssignees));
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching future sprints:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTeamSelectionAndFetchData = async (teamName: string) => {
+    if (!teamName) return;
+    
+    setSelectedTeam(teamName);
+    setShowLoader(true);
+
+    try {
+      console.log("Fetching details for team:", teamName);
+      const organisationResponse = await pService.getOrganization(teamName);
+
+      if (organisationResponse.isSuccess && organisationResponse.data) {
+        const { developer, qa } = organisationResponse.data.metadata;
+        const teamAssignees = [...developer, ...qa];
+        setAssignees(teamAssignees);
+        
+        const boardsResponse = await jiraService.getBoardsByProjectKey(
+          organisationResponse.data.metadata["jira-projects"][0].key
+        );
+
+        if (boardsResponse.isSuccess && boardsResponse.data) {
+          setBoards(boardsResponse.data);
+          
+          const boardFromUrl = searchParams.get('board');
+          if (boardFromUrl) {
+            setSelectedJiraBoardId(boardFromUrl);
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching team details:", error);
+    } finally {
+      setShowLoader(false);
     }
   };
 

--- a/gurubu-client/src/app/gurubu-planner/page.tsx
+++ b/gurubu-client/src/app/gurubu-planner/page.tsx
@@ -52,8 +52,31 @@ export default function GurubuPlanner() {
   React.useEffect(() => {
     const updateHasTeamSelected = () => {
       const hasLocalStorageTeam = !!localStorage.getItem('JIRA_DEFAULT_ASSIGNEES');
-      const hasUrlTeam = !!searchParams.get('team');
-      setHasTeamSelected(hasLocalStorageTeam || hasUrlTeam);
+      const teamFromUrl = searchParams.get('team');
+      const boardFromUrl = searchParams.get('board');
+      
+      // URL'den gelen takım ve board varsa, hemen geçerli takım seçilmiş gibi davran
+      // Bu ilk yüklemede takım seçili görünmesini sağlar
+      if (teamFromUrl && boardFromUrl) {
+        setHasTeamSelected(true);
+        return;
+      }
+      
+      // URL'den gelen takım bilgisi varsa, sadece assignees listesi varsa geçerli kabul et
+      let hasValidTeam = hasLocalStorageTeam;
+      
+      // Geçerli URL takımı kontrolü - hem URL'de takım olacak hem de localStorage'da ilgili veriler bulunacak
+      if (teamFromUrl) {
+        const storedTeamName = localStorage.getItem('JIRA_TEAM_NAME');
+        
+        // Takım adı URL ile localStorage'da aynı mı kontrol et
+        if (storedTeamName === teamFromUrl && hasLocalStorageTeam) {
+          hasValidTeam = true;
+        }
+      }
+      
+      console.log("hasValidTeam:", hasValidTeam, "teamFromUrl:", teamFromUrl, "hasLocalStorageTeam:", hasLocalStorageTeam);
+      setHasTeamSelected(hasValidTeam);
     };
   
     updateHasTeamSelected();
@@ -62,6 +85,7 @@ export default function GurubuPlanner() {
       window.removeEventListener("storage", updateHasTeamSelected);
     };
   }, [showTeamSelect, searchParams]);
+
   const handleTeamSelectClick = () => {
     setShowTeamSelect(true);
   };
@@ -179,7 +203,6 @@ export default function GurubuPlanner() {
                 hasTeamSelected={hasTeamSelected}
                 loading={loading}
                 setLoading={handleLoading}
-                selectedTeam={searchParams.get('team') || localStorage.getItem('JIRA_DEFAULT_ASSIGNEES')}
               />
               <div className="gurubu-planner-footer">
                 Developed with ❤️ by GuruBu Developers

--- a/gurubu-client/src/app/gurubu-planner/page.tsx
+++ b/gurubu-client/src/app/gurubu-planner/page.tsx
@@ -5,40 +5,53 @@ import "@/styles/gurubu-planner/style.scss";
 import PlannerNavbar from "./components/PlannerNavbar";
 import SprintDropdown from "./components/SprintDropdown";
 import { IconRefresh } from "@tabler/icons-react";
-import { Sprint } from "./components/SprintDropdown";
 import { PlannerContent } from "./components/PlannerContent";
 import { LoaderProvider } from "@/contexts/LoaderContext";
 import { ToastProvider } from "@/contexts/ToastContext";
 import { IconUsers } from "@tabler/icons-react";
-import { useSearchParams } from "next/navigation";
+import { PlannerProvider, usePlanner } from "@/contexts/PlannerContext";
 
-const AUTO_REFRESH_INTERVAL = 15; // seconds
+const AUTO_REFRESH_INTERVAL = 15;
 
 export default function GurubuPlanner() {
-  const searchParams = useSearchParams();
-  const [selectedSprint, setSelectedSprint] = React.useState<Sprint | null>(null);
-  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
+  return (
+    <LoaderProvider>
+      <ToastProvider>
+        <PlannerProvider>
+          <PlannerNavbar />
+          <PlannerContentWrapper />
+        </PlannerProvider>
+      </ToastProvider>
+    </LoaderProvider>
+  );
+}
+
+function PlannerContentWrapper() {
+  const {
+    selectedSprint,
+    setSelectedSprint,
+    refreshTrigger,
+    handleRefresh,
+    sprints,
+    setSprints,
+    hasTeamSelected,
+    showTeamSelect,
+    setShowTeamSelect,
+  } = usePlanner();
+
   const [lastUpdate, setLastUpdate] = React.useState<Date | null>(null);
   const [nextUpdateIn, setNextUpdateIn] = React.useState(AUTO_REFRESH_INTERVAL);
   const [isRefreshing, setIsRefreshing] = React.useState(false);
-  const [sprints, setSprints] = React.useState<Sprint[]>([]);
   const [autoRefreshEnabled, setAutoRefreshEnabled] = React.useState(true);
-  const [showTeamSelect, setShowTeamSelect] = React.useState(false);
-  const [hasTeamSelected, setHasTeamSelected] = React.useState(false);
-  const [loading, setLoading] = React.useState(false);
 
-  const handleLoading = (isLoading: boolean) => {
-    setLoading(isLoading);
-  };
-
-  const handleSetSprints = (sprint: Sprint[]) => {
-    setSprints(sprint);
-  };
-
-  const handleRefresh = () => {
-    setRefreshTrigger((prev) => prev + 1);
+  const refreshData = () => {
+    handleRefresh();
     setLastUpdate(new Date());
     setNextUpdateIn(AUTO_REFRESH_INTERVAL);
+  };
+
+  const handleSetSprints = (newSprints: any[]) => {
+    setSprints(newSprints);
   };
 
   const handleAutoRefreshToggle = () => {
@@ -49,54 +62,13 @@ export default function GurubuPlanner() {
     }
   };
 
-  React.useEffect(() => {
-    const updateHasTeamSelected = () => {
-      const hasLocalStorageTeam = !!localStorage.getItem('JIRA_DEFAULT_ASSIGNEES');
-      const teamFromUrl = searchParams.get('team');
-      const boardFromUrl = searchParams.get('board');
-      
-      // URL'den gelen takım ve board varsa, hemen geçerli takım seçilmiş gibi davran
-      // Bu ilk yüklemede takım seçili görünmesini sağlar
-      if (teamFromUrl && boardFromUrl) {
-        setHasTeamSelected(true);
-        return;
-      }
-      
-      // URL'den gelen takım bilgisi varsa, sadece assignees listesi varsa geçerli kabul et
-      let hasValidTeam = hasLocalStorageTeam;
-      
-      // Geçerli URL takımı kontrolü - hem URL'de takım olacak hem de localStorage'da ilgili veriler bulunacak
-      if (teamFromUrl) {
-        const storedTeamName = localStorage.getItem('JIRA_TEAM_NAME');
-        
-        // Takım adı URL ile localStorage'da aynı mı kontrol et
-        if (storedTeamName === teamFromUrl && hasLocalStorageTeam) {
-          hasValidTeam = true;
-        }
-      }
-      
-      console.log("hasValidTeam:", hasValidTeam, "teamFromUrl:", teamFromUrl, "hasLocalStorageTeam:", hasLocalStorageTeam);
-      setHasTeamSelected(hasValidTeam);
-    };
-  
-    updateHasTeamSelected();
-    window.addEventListener('storage', updateHasTeamSelected);
-    return () => {
-      window.removeEventListener("storage", updateHasTeamSelected);
-    };
-  }, [showTeamSelect, searchParams]);
-
   const handleTeamSelectClick = () => {
     setShowTeamSelect(true);
   };
 
-  const handleCloseTeamSelect = () => {
-    setShowTeamSelect(false);
-  };
-
   React.useEffect(() => {
     if (hasTeamSelected) {
-      handleRefresh();
+      refreshData();
     }
   }, [hasTeamSelected]);
 
@@ -104,7 +76,7 @@ export default function GurubuPlanner() {
     if (!autoRefreshEnabled) return;
 
     const intervalId = setInterval(() => {
-      handleRefresh();
+      refreshData();
     }, AUTO_REFRESH_INTERVAL * 1000);
 
     return () => clearInterval(intervalId);
@@ -136,81 +108,65 @@ export default function GurubuPlanner() {
   };
 
   return (
-    <LoaderProvider>
-      <ToastProvider>
-        <PlannerNavbar />
-        <main className="gurubu-planner-container">
-          <div className="gurubu-planner-content">
-            <div className="gurubu-planner-card">
-              {hasTeamSelected && (
-                <div className="gurubu-planner-controls">
-                  <div className="gurubu-planner-controls-left">
-                  <SprintDropdown
-                    sprints={sprints}
-                    setSprints={handleSetSprints}
-                    selectedSprint={selectedSprint}
-                    onSprintSelect={setSelectedSprint}
-                  />
-                  <button
-                    className="select-team-button"
-                    onClick={handleTeamSelectClick}
-                  >
-                    <IconUsers size={20} />
-                      {hasTeamSelected ? 'Change Team' : 'Select Team'}
-                    </button>
-                  </div>
-                  <div className="gurubu-planner-controls-right">
-                    <div className="update-info">
-                      <span className="last-update">{formatUpdateInfo()}</span>
-                      {autoRefreshEnabled && (
-                        <span className="next-update">
-                          Next update in {nextUpdateIn}s
-                        </span>
-                      )}
-                    </div>
-                    <button
-                      className="auto-refresh-toggle"
-                      onClick={handleAutoRefreshToggle}
-                    >
-                      {autoRefreshEnabled
-                        ? "Stop Auto Refresh"
-                        : "Enable Auto Refresh"}
-                    </button>
-                    <button
-                      className={`gurubu-planner-sync-button ${
-                        isRefreshing ? "is-refreshing" : ""
-                      }`}
-                      onClick={handleRefresh}
-                      title="Sync data"
-                      disabled={isRefreshing}
-                    >
-                      <IconRefresh size={18} className="sync-icon" />
-                      <span>Sync</span>
-                    </button>
-                  </div>
+    <main className="gurubu-planner-container">
+      <div className="gurubu-planner-content">
+        <div className="gurubu-planner-card">
+          {hasTeamSelected && (
+            <div className="gurubu-planner-controls">
+              <div className="gurubu-planner-controls-left">
+                <SprintDropdown
+                  sprints={sprints}
+                  setSprints={handleSetSprints}
+                  selectedSprint={selectedSprint}
+                  onSprintSelect={setSelectedSprint}
+                />
+                <button
+                  className="select-team-button"
+                  onClick={handleTeamSelectClick}
+                >
+                  <IconUsers size={20} />
+                  {hasTeamSelected ? 'Change Team' : 'Select Team'}
+                </button>
+              </div>
+              <div className="gurubu-planner-controls-right">
+                <div className="update-info">
+                  <span className="last-update">{formatUpdateInfo()}</span>
+                  {autoRefreshEnabled && (
+                    <span className="next-update">
+                      Next update in {nextUpdateIn}s
+                    </span>
+                  )}
                 </div>
-              )}
-              <PlannerContent
-                setSprints={handleSetSprints}
-                handleRefresh={handleRefresh}
-                selectedSprintId={selectedSprint?.id || null}
-                refreshTrigger={refreshTrigger}
-                selectedSprint={selectedSprint}
-                onSprintSelect={setSelectedSprint}
-                showTeamSelect={showTeamSelect}
-                handleCloseTeamSelect={handleCloseTeamSelect}
-                handleTeamSelectClick={handleTeamSelectClick}
-                hasTeamSelected={hasTeamSelected}
-                loading={loading}
-                setLoading={handleLoading}
-              />
-              <div className="gurubu-planner-footer">
-                Developed with ❤️ by GuruBu Developers
+                <button
+                  className="auto-refresh-toggle"
+                  onClick={handleAutoRefreshToggle}
+                >
+                  {autoRefreshEnabled
+                    ? "Stop Auto Refresh"
+                    : "Enable Auto Refresh"}
+                </button>
+                <button
+                  className={`gurubu-planner-sync-button ${
+                    isRefreshing ? "is-refreshing" : ""
+                  }`}
+                  onClick={refreshData}
+                  title="Sync data"
+                  disabled={isRefreshing}
+                >
+                  <IconRefresh size={18} className="sync-icon" />
+                  <span>Sync</span>
+                </button>
               </div>
             </div>
+          )}
+          <PlannerContent
+            selectedSprintId={selectedSprint?.id || null}
+          />
+          <div className="gurubu-planner-footer">
+            Developed with ❤️ by GuruBu Developers
           </div>
-        </main>
-      </ToastProvider>
-    </LoaderProvider>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/gurubu-client/src/app/styles/gurubu-planner/style.scss
+++ b/gurubu-client/src/app/styles/gurubu-planner/style.scss
@@ -10,8 +10,26 @@
   padding: 1rem 2rem;
 
   .gurubu-planner-navbar-content {
+    display: flex;
+    justify-content: space-between;
     max-width: 1200px;
     margin: 0 auto;
+
+    .gurubu-planner-navbar-content-copy-link {
+      display: flex;
+      align-items: center;
+      padding: $space-small $space-medium;
+      gap: 0 $space-small;
+      background-color: $primary-50;
+      color: $primary-700;
+      font-size: $font-size-paragraph-5;
+      font-weight: $semibold;
+      border: none;
+      outline: none;
+      border-radius: $radius-large;
+      height: fit-content;
+      cursor: pointer;
+    }
   }
 }
 
@@ -25,6 +43,21 @@
     width: 100%;
     max-width: 1200px;
     margin: 0 auto;
+    .selected-team-title {
+      font-weight: 600;
+      color: var(--text-primary);
+      font-size: 0.875rem;
+      display: flex;
+      align-items: center;
+
+      &:first-child {
+        justify-content: flex-start;
+      }
+
+      &:not(:first-child) {
+        justify-content: center;
+      }
+    }
 
     .gurubu-planner-title {
       font-size: 2.5rem;
@@ -40,6 +73,10 @@
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
       padding: 1.5rem;
       position: relative;
+
+      .gurubu-planner-content {
+        padding: 0;
+      }
 
       .gurubu-planner-subtitle {
         font-size: 1.5rem;
@@ -143,6 +180,7 @@
     display: grid;
     grid-template-columns: minmax(200px, 1.5fr) repeat(4, 1fr);
     gap: 1rem;
+    margin-top: 0.5rem;
     padding: 1rem;
     background-color: rgba(79, 70, 229, 0.1);
     border-radius: 6px 6px 0 0;
@@ -295,10 +333,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 1rem;
     background-color: var(--background);
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 6px;
+    min-width: 300px;
     cursor: pointer;
     transition: all 0.2s;
 
@@ -390,7 +429,7 @@
   }
 
   &-error {
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 1rem;
     color: #EF4444;
     background-color: rgba(239, 68, 68, 0.1);
     border-radius: 6px;
@@ -407,6 +446,18 @@
 
   .gurubu-planner-dropdown {
     flex: 1;
+
+    &-error {
+      max-width: 361px;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  }
+  .gurubu-planner-controls-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
   }
 
   .gurubu-planner-controls-right {
@@ -439,7 +490,6 @@
 
 .auto-refresh-toggle {
   padding: 0.5rem 1rem;
-  margin-right: 0.5rem;
   border-radius: 6px;
   border: 1px solid #E5E7EB;
   background-color: white;


### PR DESCRIPTION
# Gurubu Planner Share Link Feature

This PR adds a link-sharing functionality to Gurubu Planner. Users can now share their planner configuration via URL, allowing others to bypass the initial team selection process and directly access the same planner view. Additionally, I've created a new PlannerContext to improve state management throughout the application.

## Key Features
- Added link sharing capability to Gurubu Planner
- Created a new PlannerContext for better state management
- Implemented URL parameter handling for team and board selection
- Streamlined user experience by enabling direct access via shared links

## Technical Implementation
- Created PlannerContext to centralize planner state management
- Added support for reading team and board parameters from URL
- Implemented URL state synchronization with application state
- Fixed issues with team/board selection and persistence

## Related Issues
Closes #354