### PR TITLE
fix: update grooming board participants alignment and padding

### DIFF
--- a/gurubu-client/src/app/styles/room/grooming-board/grooming-board-participants.scss
+++ b/gurubu-client/src/app/styles/room/grooming-board/grooming-board-participants.scss
@@ -104,7 +104,8 @@
     display: flex;
     gap: 0 $space-large;
     width: 100%;
-    justify-content: space-around;
+    justify-content: flex-end;
+    padding-right: 14px;
   }
   &__point-card {
     border-radius: 50%;


### PR DESCRIPTION
An alignment issue in the participants list will be fixed after this pull request is merged. I've added screenshots below.

**Problematic:**
<img width="333" alt="Problematic" src="https://github.com/user-attachments/assets/d2743d31-610f-4132-a971-80575ac5e3f4" />

**With the fix provided in this PR:**
<img width="330" alt="With the fix provided in this PR" src="https://github.com/user-attachments/assets/16f4db29-566b-4f38-96e2-4d8674998afc" />