### PR TITLE
feat: add 10s and 30s quick time options to timer

### DIFF
--- a/gurubu-client/src/app/components/room/grooming-navbar/timer.tsx
+++ b/gurubu-client/src/app/components/room/grooming-navbar/timer.tsx
@@ -14,6 +14,8 @@ interface Props {
 }
 
 const TIME_OPTIONS = [
+  { label: "+10s", minutes: 10 / 60 },
+  { label: "+30s", minutes: 30 / 60 },
   { label: "+1", minutes: 1 },
   { label: "+5", minutes: 5 },
   { label: "+10", minutes: 10 },


### PR DESCRIPTION
We needed shorter intervals to make the timer feature usable for quick discussions, so added +10s and +30s options alongside existing minute-based intervals. This allows for more granular time control and makes the timer practical for brief activities.