### PR TITLE
feat: implement background music controls and UI in RetroHeader

### DIFF
--- a/gurubu-client/src/app/components/room/retro-board/RetroHeader.tsx
+++ b/gurubu-client/src/app/components/room/retro-board/RetroHeader.tsx
@@ -1,16 +1,30 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { IconAlarm, IconMusic, IconDownload, IconUpload, IconShare, IconFileTypeCsv, IconFileTypePdf, IconChecklist, IconLink, IconUserPlus, IconEye, IconClipboardList, IconFlag } from "@tabler/icons-react";
+import {
+  IconAlarm,
+  IconMusic,
+  IconDownload,
+  IconUpload,
+  IconShare,
+  IconFileTypeCsv,
+  IconFileTypePdf,
+  IconChecklist,
+  IconLink,
+  IconUserPlus,
+  IconEye,
+  IconClipboardList,
+  IconFlag,
+  IconPlayerPause,
+  IconPlayerPlay,
+  IconVolume,
+} from "@tabler/icons-react";
 import RetroTimerV2 from "./retro-timer-v2";
-import RetroMusicPlayer from "./retro-music-player";
 
 interface RetroHeaderProps {
   isOwner: boolean;
   showTimer: boolean;
   setShowTimer: (value: boolean) => void;
-  showMusic: boolean;
-  setShowMusic: (value: boolean) => void;
   timer: any;
   music: any;
   participants: any[];
@@ -38,8 +52,6 @@ const RetroHeader = ({
   isOwner,
   showTimer,
   setShowTimer,
-  showMusic,
-  setShowMusic,
   timer,
   music,
   participants,
@@ -63,37 +75,135 @@ const RetroHeader = ({
   isReadonly,
 }: RetroHeaderProps) => {
   const [showExportDropdown, setShowExportDropdown] = useState(false);
-  const [showRevealedBadge, setShowRevealedBadge] = useState(false);
   const [showInviteDropdown, setShowInviteDropdown] = useState(false);
+  const [showMusicDropdown, setShowMusicDropdown] = useState(false);
+  const [pendingPlay, setPendingPlay] = useState(false);
+  const [musicUrl, setMusicUrl] = useState("");
+  const [localVolume, setLocalVolume] = useState(50);
+  const [isLocallyPaused, setIsLocallyPaused] = useState(false);
+
   const exportRef = useRef<HTMLDivElement>(null);
   const inviteRef = useRef<HTMLDivElement>(null);
+  const musicRef = useRef<HTMLDivElement>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const hasInteracted = useRef(false);
 
+  type MusicPlatform = "audio" | "youtube";
+
+  // Click outside
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+      if (exportRef.current && !exportRef.current.contains(e.target as Node))
         setShowExportDropdown(false);
-      }
-      if (inviteRef.current && !inviteRef.current.contains(e.target as Node)) {
+      if (inviteRef.current && !inviteRef.current.contains(e.target as Node))
         setShowInviteDropdown(false);
-      }
+      if (musicRef.current && !musicRef.current.contains(e.target as Node))
+        setShowMusicDropdown(false);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  // Show revealed badge when cards are revealed, auto-hide after 5 seconds
-  useEffect(() => {
-    if (cardsRevealed) {
-      setShowRevealedBadge(true);
-      const timer = setTimeout(() => setShowRevealedBadge(false), 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [cardsRevealed]);
+  const detectPlatform = (url: string): MusicPlatform => {
+    if (url.includes("youtube.com") || url.includes("youtu.be"))
+      return "youtube";
+    return "audio";
+  };
 
-  const inviteUrl = typeof window !== 'undefined' ? `${window.location.origin}/retro/${roomId}` : '';
+  const platform = music.url ? detectPlatform(music.url) : "audio";
+
+  // Load volume from localStorage
+  useEffect(() => {
+    const saved = localStorage.getItem("retroMusicVolume");
+    if (saved) setLocalVolume(Number(saved));
+  }, []);
+
+  // Sync music URL from prop
+  useEffect(() => {
+    if (music.url) setMusicUrl(music.url);
+  }, [music.url]);
+
+  // Reset local pause when owner stops
+  useEffect(() => {
+    if (!music.isPlaying) setIsLocallyPaused(false);
+  }, [music.isPlaying]);
+
+  // Audio instance
+  useEffect(() => {
+    audioRef.current = new Audio();
+    audioRef.current.loop = true;
+    audioRef.current.volume = localVolume / 100;
+    return () => {
+      audioRef.current?.pause();
+      audioRef.current = null;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Volume
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.volume = localVolume / 100;
+  }, [localVolume]);
+
+  // Interaction tracker
+  useEffect(() => {
+    const mark = () => {
+      hasInteracted.current = true;
+    };
+    document.addEventListener("click", mark, { once: true });
+    return () => document.removeEventListener("click", mark);
+  }, []);
+
+  // Play/Pause
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || platform !== "audio" || !music.url) return;
+
+    const handleError = () => {
+      console.error("Audio load failed:", music.url);
+      onMusicUpdate({ ...music, isPlaying: false, error: "unsupported" });
+    };
+
+    audio.addEventListener("error", handleError);
+    audio.pause();
+    audio.src = music.url;
+    audio.load();
+
+    if (!music.isPlaying) {
+      audio.removeEventListener("error", handleError);
+      return;
+    }
+
+    if (!hasInteracted.current) {
+      setPendingPlay(true);
+      audio.removeEventListener("error", handleError);
+      return;
+    }
+
+    audio.play().catch(() => {
+      onMusicUpdate({ ...music, isPlaying: false, error: "unsupported" });
+    });
+
+    return () => audio.removeEventListener("error", handleError);
+  }, [music.isPlaying, music.url, platform]);
+
+  const handleSetMusic = () => {
+    if (!musicUrl.trim()) return;
+    onMusicUpdate({ url: musicUrl, isPlaying: true });
+  };
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = Number(e.target.value);
+    setLocalVolume(newVolume);
+    localStorage.setItem("retroMusicVolume", newVolume.toString());
+  };
+
+  const inviteUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/retro/${roomId}`
+      : "";
 
   const sortedParticipants = [...participants].sort((a, b) =>
-    a.nickname.localeCompare(b.nickname, 'tr', { sensitivity: 'base' })
+    a.nickname.localeCompare(b.nickname, "tr", { sensitivity: "base" }),
   );
 
   return (
@@ -104,21 +214,24 @@ const RetroHeader = ({
           {sortedParticipants.map((participant) => (
             <div
               key={participant.userID}
-              className={`retro-board__participant ${participant.isAfk ? 'retro-board__participant--afk' : ''}`}
+              className={`retro-board__participant ${participant.isAfk ? "retro-board__participant--afk" : ""}`}
               title={participant.nickname}
             >
               {participant.avatarSvg && (
-                <div dangerouslySetInnerHTML={{ __html: participant.avatarSvg }} />
+                <div
+                  dangerouslySetInnerHTML={{ __html: participant.avatarSvg }}
+                />
               )}
-              {participant.isAfk && <span className="retro-board__participant-afk">AFK</span>}
+              {participant.isAfk && (
+                <span className="retro-board__participant-afk">AFK</span>
+              )}
             </div>
           ))}
         </div>
       </div>
 
       <div className="retro-board__header-right">
-        {/* Expanded timer */}
-        {(isOwner && showTimer) || (!isOwner && timer.isRunning) ? (
+        {((isOwner && showTimer) || (!isOwner && timer.isRunning)) && (
           <div className="retro-board__timer">
             <RetroTimerV2
               timer={timer}
@@ -126,22 +239,39 @@ const RetroHeader = ({
               onTimerUpdate={onTimerUpdate}
             />
           </div>
-        ) : null}
-
-        {/* Expanded music */}
-        {(music.isPlaying || (isOwner && showMusic)) && (
-          <div className="retro-board__music">
-            <RetroMusicPlayer
-              music={music}
-              isOwner={isOwner}
-              onMusicUpdate={onMusicUpdate}
-            />
-          </div>
         )}
 
-        {/* All icon buttons in a single row */}
+        {/* Non-owner music control */}
+        {(pendingPlay || music.isPlaying) && !isOwner && (
+          <button
+            className={`retro-board__control-btn ${music.isPlaying && !pendingPlay && !isLocallyPaused ? "active" : ""}`}
+            onClick={() => {
+              if (pendingPlay) {
+                hasInteracted.current = true;
+                audioRef.current?.play().catch(console.error);
+                setPendingPlay(false);
+                setIsLocallyPaused(false);
+              } else if (isLocallyPaused) {
+                audioRef.current?.play().catch(console.error);
+                setIsLocallyPaused(false);
+              } else {
+                audioRef.current?.pause();
+                setIsLocallyPaused(true);
+              }
+            }}
+            title={
+              pendingPlay || isLocallyPaused ? "Play Music" : "Pause Music"
+            }
+          >
+            {pendingPlay || isLocallyPaused ? (
+              <IconPlayerPlay size={20} />
+            ) : (
+              <IconPlayerPause size={20} />
+            )}
+          </button>
+        )}
+
         <div className="retro-board__controls">
-          {/* Timer toggle - owner only */}
           {isOwner && !isReadonly && (
             <button
               className={`retro-board__control-btn ${showTimer ? "active" : ""}`}
@@ -152,25 +282,101 @@ const RetroHeader = ({
             </button>
           )}
 
-          {/* Music - Soon */}
+          {/* Music - owner only */}
           {isOwner && !isReadonly && (
-            <div className="retro-board__control-wrapper">
+            <div className="retro-board__dropdown-wrapper" ref={musicRef}>
               <button
-                className="retro-board__control-btn retro-board__control-btn--disabled"
-                disabled
-                title="Background Music (Coming Soon)"
+                className={`retro-board__control-btn ${showMusicDropdown || music.isPlaying ? "active" : ""}`}
+                onClick={() => {
+                  setShowMusicDropdown(!showMusicDropdown);
+                  setShowExportDropdown(false);
+                  setShowInviteDropdown(false);
+                }}
+                title="Background Music"
               >
                 <IconMusic size={20} />
               </button>
-              <span className="retro-board__control-tooltip">Background Music - Soon</span>
+              {showMusicDropdown && (
+                <div className="retro-board__dropdown retro-board__dropdown--music">
+                  <div className="retro-board__dropdown-header">
+                    Background Music
+                  </div>
+                  <div className="retro-board__music-url-input">
+                    <input
+                      type="url"
+                      value={musicUrl}
+                      onChange={(e) => setMusicUrl(e.target.value)}
+                      placeholder="Audio URL (YouTube, .mp3, .wav)"
+                      className="retro-board__dropdown-url-input"
+                    />
+                    <button
+                      className="retro-board__dropdown-btn retro-board__dropdown-btn--primary"
+                      onClick={handleSetMusic}
+                      disabled={!musicUrl.trim()}
+                    >
+                      Set Music
+                    </button>
+                  </div>
+                  {music.url && (
+                    <>
+                      <div className="retro-board__dropdown-divider" />
+                      <div className="retro-board__music-controls">
+                        <button
+                          className="retro-board__dropdown-item"
+                          onClick={() =>
+                            onMusicUpdate({
+                              ...music,
+                              isPlaying: !music.isPlaying,
+                            })
+                          }
+                        >
+                          {music.isPlaying ? (
+                            <>
+                              <IconPlayerPause size={18} />
+                              <span>Pause</span>
+                            </>
+                          ) : (
+                            <>
+                              <IconPlayerPlay size={18} />
+                              <span>Play</span>
+                            </>
+                          )}
+                        </button>
+                        {platform === "audio" && (
+                          <div className="retro-board__music-volume">
+                            <IconVolume size={18} />
+                            <input
+                              type="range"
+                              min="0"
+                              max="100"
+                              value={localVolume}
+                              onChange={handleVolumeChange}
+                              className="retro-board__volume-slider"
+                            />
+                            <span>{localVolume}%</span>
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
+                  <div className="retro-board__dropdown-hint">
+                    💡Youtube & Direct audio file links only (.mp3, .wav)
+                  </div>
+                  {musicUrl && music.error === "unsupported" && (
+                    <div className="retro-board__dropdown-error">
+                      ⚠️ Audio format not supported or URL is invalid
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
 
-          {/* Export Dropdown - owner only */}
+          {/* Export - owner only */}
           {isOwner && (
             <div className="retro-board__dropdown-wrapper" ref={exportRef}>
               <button
-                className={`retro-board__control-btn ${showExportDropdown ? 'active' : ''}`}
+                className={`retro-board__control-btn ${showExportDropdown ? "active" : ""}`}
                 onClick={() => {
                   setShowExportDropdown(!showExportDropdown);
                   setShowInviteDropdown(false);
@@ -181,34 +387,57 @@ const RetroHeader = ({
               </button>
               {showExportDropdown && (
                 <div className="retro-board__dropdown">
-                  <button className="retro-board__dropdown-item" onClick={() => { onExportCSV(); setShowExportDropdown(false); }}>
+                  <button
+                    className="retro-board__dropdown-item"
+                    onClick={() => {
+                      onExportCSV();
+                      setShowExportDropdown(false);
+                    }}
+                  >
                     <IconFileTypeCsv size={18} />
                     <span>Export CSV</span>
                   </button>
-                  <button className="retro-board__dropdown-item" onClick={() => { onExportPDF(); setShowExportDropdown(false); }}>
+                  <button
+                    className="retro-board__dropdown-item"
+                    onClick={() => {
+                      onExportPDF();
+                      setShowExportDropdown(false);
+                    }}
+                  >
                     <IconFileTypePdf size={18} />
                     <span>Export PDF</span>
                   </button>
                   <div className="retro-board__dropdown-divider" />
-                  <button className="retro-board__dropdown-item" onClick={() => { onExportActionItemsPDF(); setShowExportDropdown(false); }}>
+                  <button
+                    className="retro-board__dropdown-item"
+                    onClick={() => {
+                      onExportActionItemsPDF();
+                      setShowExportDropdown(false);
+                    }}
+                  >
                     <IconChecklist size={18} />
                     <span>Export Action Items</span>
                   </button>
                   <div className="retro-board__dropdown-divider" />
-                  <div className="retro-board__dropdown-item retro-board__dropdown-item--disabled" title="Import from Ludi, MetroRetro, Zoom Retro (Coming Soon)">
+                  <div
+                    className="retro-board__dropdown-item retro-board__dropdown-item--disabled"
+                    title="Import from Ludi, MetroRetro, Zoom Retro (Coming Soon)"
+                  >
                     <IconUpload size={18} />
                     <span>Import Cards</span>
-                    <span className="retro-board__dropdown-soon">Import from Other Tools - Soon</span>
+                    <span className="retro-board__dropdown-soon">
+                      Import from Other Tools - Soon
+                    </span>
                   </div>
                 </div>
               )}
             </div>
           )}
 
-          {/* Invite Dropdown */}
+          {/* Invite */}
           <div className="retro-board__dropdown-wrapper" ref={inviteRef}>
             <button
-              className={`retro-board__control-btn ${showInviteDropdown ? 'active' : ''}`}
+              className={`retro-board__control-btn ${showInviteDropdown ? "active" : ""}`}
               onClick={() => {
                 setShowInviteDropdown(!showInviteDropdown);
                 setShowExportDropdown(false);
@@ -229,7 +458,13 @@ const RetroHeader = ({
                     onClick={(e) => (e.target as HTMLInputElement).select()}
                   />
                 </div>
-                <button className="retro-board__dropdown-invite-btn" onClick={() => { onCopyInviteLink(); setShowInviteDropdown(false); }}>
+                <button
+                  className="retro-board__dropdown-invite-btn"
+                  onClick={() => {
+                    onCopyInviteLink();
+                    setShowInviteDropdown(false);
+                  }}
+                >
                   <IconUserPlus size={18} />
                   <span>Copy Invite Link</span>
                 </button>
@@ -237,10 +472,8 @@ const RetroHeader = ({
             )}
           </div>
 
-          {/* Divider between tool buttons and action buttons */}
           <div className="retro-board__divider" />
 
-          {/* Reveal Cards - once revealed, buttons disappear (no hiding back) */}
           {hasCards && !isReadonly && !cardsRevealed && (
             <div className="retro-board__reveal-controls">
               <button
@@ -264,7 +497,6 @@ const RetroHeader = ({
             </div>
           )}
 
-          {/* Previous Action Items - disabled for now */}
           <div className="retro-board__control-wrapper">
             <button
               className="retro-board__control-btn retro-board__control-btn--disabled"
@@ -273,10 +505,11 @@ const RetroHeader = ({
             >
               <IconClipboardList size={20} />
             </button>
-            <span className="retro-board__control-tooltip">Previous Actions - Soon</span>
+            <span className="retro-board__control-tooltip">
+              Previous Actions - Soon
+            </span>
           </div>
 
-          {/* End Retro - Admin Only */}
           {isOwner && !isReadonly && (
             <button
               className="retro-board__end-retro-btn"
@@ -288,7 +521,6 @@ const RetroHeader = ({
             </button>
           )}
 
-          {/* Readonly Badge */}
           {isReadonly && (
             <div className="retro-board__readonly-badge">
               <span>Read Only</span>

--- a/gurubu-client/src/app/components/room/retro-board/retro-board.tsx
+++ b/gurubu-client/src/app/components/room/retro-board/retro-board.tsx
@@ -54,7 +54,6 @@ const RetroBoard = ({ roomId }: IProps) => {
   const [newCardImage, setNewCardImage] = useState<string | null>(null);
   const [newCardColor, setNewCardColor] = useState<string | null>(null);
   const [showTimer, setShowTimer] = useState(false);
-  const [showMusic, setShowMusic] = useState(false);
   const [selectedStamp, setSelectedStamp] = useState<string | null>(null);
   const [draggedCard, setDraggedCard] = useState<{color: string, emoji: string} | null>(null);
   const [draggedImage, setDraggedImage] = useState<any>(null);
@@ -821,8 +820,6 @@ const RetroBoard = ({ roomId }: IProps) => {
             isOwner={isOwner}
             showTimer={showTimer}
             setShowTimer={setShowTimer}
-            showMusic={showMusic}
-            setShowMusic={setShowMusic}
             timer={timer}
             music={music}
             participants={participantsWithAvatars}

--- a/gurubu-client/src/app/styles/room/retro-board/retro-board.scss
+++ b/gurubu-client/src/app/styles/room/retro-board/retro-board.scss
@@ -3313,6 +3313,158 @@
   }
 }
 
+// Music Dropdown Styles
+.retro-board__dropdown--music {
+  min-width: 340px;
+  padding: 0.75rem;
+}
+
+.retro-board__dropdown-header {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 0.75rem;
+  padding: 0 0.25rem;
+}
+
+.retro-board__music-url-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  input {
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    color: #2d3748;
+    outline: none;
+    transition: all 0.2s;
+
+    &:focus {
+      border-color: #667eea;
+      background: #f7fafc;
+    }
+
+    &::placeholder {
+      color: #a0aec0;
+    }
+  }
+}
+
+.retro-board__dropdown-btn {
+  width: 100%;
+  padding: 0.625rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &--primary {
+    background: #667eea;
+    color: white;
+
+    &:hover:not(:disabled) {
+      background: #5568d3;
+      transform: translateY(-1px);
+    }
+
+    &:disabled {
+      background: #cbd5e0;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+}
+
+.retro-board__music-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.retro-board__music-volume {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  background: #f7fafc;
+  border-radius: 8px;
+  color: #4a5568;
+}
+
+.retro-board__volume-slider {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: #e2e8f0;
+  outline: none;
+  -webkit-appearance: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #667eea;
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover {
+      transform: scale(1.2);
+      background: #5568d3;
+    }
+  }
+
+  &::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #667eea;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s;
+
+    &:hover {
+      transform: scale(1.2);
+      background: #5568d3;
+    }
+  }
+}
+
+.retro-board__volume-value {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #667eea;
+  min-width: 36px;
+  text-align: right;
+}
+
+.retro-board__dropdown-hint {
+  font-size: 0.75rem;
+  color: #a0aec0;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  background: #f7fafc;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.retro-board__dropdown-error {
+  font-size: 0.75rem;
+  color: #ef4444;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 8px;
+  text-align: center;
+}
+
 .retro-column__card-bottom-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Header'a background music özelliği eklendi. Oda sahibi müzik URL'sini girerek tüm katılımcılar için müzik başlatabilir.

Desteklenen formatlar:
- Direct audio links (.mp3, .wav)
- YouTube links

Özellikler:
- Owner müziği başlatır/durdurur, volume ayarlar (local)
- Non-owner katılımcılar kendi tarafında play/pause yapabilir
- Desteklenmeyen format/geçersiz URL durumunda kullanıcıya hata gösterilir
- Volume tercihi localStorage'da saklanır

Test:
- .mp3: https://projects.skratchdot.com/audio-files/loops/loop336.mp3
- YouTube: https://youtube.com/...

<img width="766" height="396" alt="Screenshot 2026-06-06 134348" src="https://github.com/user-attachments/assets/f9d06031-e2a8-460d-a4f5-a1fe70ce178d" />
